### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,6 +7,9 @@ on:
     types: [requested]
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   docker:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/eharrow/pico-starlight-node/security/code-scanning/3](https://github.com/eharrow/pico-starlight-node/security/code-scanning/3)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimum permissions required for the workflow to operate correctly. In this case, the workflow primarily involves Docker-related actions, which do not require write access to repository contents but may need read access for its operations. Therefore, we will set `contents: read` at the root of the workflow. This ensures that all jobs inherit this minimal permission unless explicitly overridden.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
