### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Build
 
 on: [push, pull_request]


### PR DESCRIPTION
Potential fix for [https://github.com/eharrow/pico-starlight-node/security/code-scanning/2](https://github.com/eharrow/pico-starlight-node/security/code-scanning/2)

To resolve this issue, add a `permissions` block at the root level of the workflow (under the `name` field). Since the workflow primarily installs dependencies and runs tests, it does not appear to require write permissions. The least-required permission is `contents: read`, which allows the workflow to read the repository contents without enabling write access.

Changes need to be made to `.github/workflows/main.yml`:
1. Add a `permissions` block with `contents: read` at the root of the workflow.
2. Ensure no further changes are needed, as the steps do not require additional permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
